### PR TITLE
Reset contentOffset after reloadData to fix a crash.

### DIFF
--- a/Sources/InputAssistantCollectionView.swift
+++ b/Sources/InputAssistantCollectionView.swift
@@ -21,7 +21,8 @@ class InputAssistantCollectionView: UICollectionView {
     
     init() {
         let layout = UICollectionViewFlowLayout()
-        layout.estimatedItemSize = UICollectionViewFlowLayoutAutomaticSize
+        layout.estimatedItemSize = CGSize(width: 100, height: 41)
+        layout.itemSize = UICollectionViewFlowLayoutAutomaticSize
         layout.scrollDirection = .horizontal
         layout.minimumInteritemSpacing = 10
         layout.sectionInset = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10)

--- a/Sources/InputAssistantCollectionView.swift
+++ b/Sources/InputAssistantCollectionView.swift
@@ -21,8 +21,7 @@ class InputAssistantCollectionView: UICollectionView {
     
     init() {
         let layout = UICollectionViewFlowLayout()
-        layout.estimatedItemSize = CGSize(width: 100, height: 41)
-        layout.itemSize = UICollectionViewFlowLayoutAutomaticSize
+        layout.estimatedItemSize = UICollectionViewFlowLayoutAutomaticSize
         layout.scrollDirection = .horizontal
         layout.minimumInteritemSpacing = 10
         layout.sectionInset = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10)

--- a/Sources/InputAssistantCollectionView.swift
+++ b/Sources/InputAssistantCollectionView.swift
@@ -47,10 +47,10 @@ class InputAssistantCollectionView: UICollectionView {
     
     override func reloadData() {
         super.reloadData()
-		
-		// Need to reset scrolling position,
-		// since the self sizing cells can cause a crash when scrolling back after a reloadData.
-		contentOffset = .zero
+
+        // Need to reset scrolling position,
+        // since the self sizing cells can cause a crash when scrolling back after a reloadData.
+        contentOffset = .zero
 		
         noSuggestionsLabel.text = self.inputAssistantView?.dataSource?.textForEmptySuggestionsInInputAssistantView()
         noSuggestionsLabel.isHidden = self.numberOfItems(inSection: 0) > 0

--- a/Sources/InputAssistantCollectionView.swift
+++ b/Sources/InputAssistantCollectionView.swift
@@ -47,6 +47,11 @@ class InputAssistantCollectionView: UICollectionView {
     
     override func reloadData() {
         super.reloadData()
+		
+		// Need to reset scrolling position,
+		// since the self sizing cells can cause a crash when scrolling back after a reloadData.
+		contentOffset = .zero
+		
         noSuggestionsLabel.text = self.inputAssistantView?.dataSource?.textForEmptySuggestionsInInputAssistantView()
         noSuggestionsLabel.isHidden = self.numberOfItems(inSection: 0) > 0
     }


### PR DESCRIPTION
Fixes a crash that would occur when reloadData is called and the new data has fewer items and requires the collection view to layout its cells.

Fixes #1.