### PR TITLE
Set delaysContentTouches to false

### DIFF
--- a/Sources/InputAssistantCollectionView.swift
+++ b/Sources/InputAssistantCollectionView.swift
@@ -32,6 +32,7 @@ class InputAssistantCollectionView: UICollectionView {
         backgroundColor = .clear
         showsHorizontalScrollIndicator = false
         showsVerticalScrollIndicator = false
+        delaysContentTouches = false
         dataSource = self
         
         noSuggestionsLabel.textAlignment = .center


### PR DESCRIPTION
Set delaysContentTouches to false to get immediate visual feedback for touches, which is how the system keyboard behaves.